### PR TITLE
Change coordinate scale to low/high noise scale

### DIFF
--- a/src/main/resources/assets/farlands/lang/en_us.json
+++ b/src/main/resources/assets/farlands/lang/en_us.json
@@ -42,15 +42,15 @@
 
   "config.farlands.invalid": "Invalid!",
 
-  "config.farlands.coordinateScale": "Coordinate scale",
-  "config.farlands.heightScale": "Height scale",
-  "config.farlands.coordinateScaleMultiplier": "Coordinate scale multiplier",
-  "config.farlands.heightScaleMultiplier": "Height scale multiplier",
+  "config.farlands.coordinateScale": "Low/high noise scale (XZ)",
+  "config.farlands.heightScale": "Low/high noise scale (Y)",
+  "config.farlands.coordinateScaleMultiplier": "Low/high noise scale multiplier (XZ)",
+  "config.farlands.heightScaleMultiplier": "Low/high noise scale multiplier (Y)",
 
-  "config.farlands.coordinateScale.tooltip": "The world's coordinate scale.",
-  "config.farlands.heightScale.tooltip": "The world's height scale.",
-  "config.farlands.coordinateScaleMultiplier.tooltip": "The coordinate scale multiplier (coordinate scale * multiplier).",
-  "config.farlands.heightScaleMultiplier.tooltip": "The height scale multiplier (height scale * multiplier).",
+  "config.farlands.coordinateScale.tooltip": "The low noise and high noise scale on the XZ plane.",
+  "config.farlands.heightScale.tooltip": "The low noise and high noise scale on the Y axis.",
+  "config.farlands.coordinateScaleMultiplier.tooltip": "The low/high noise scale multiplier (XZ) (scale * multiplier).",
+  "config.farlands.heightScaleMultiplier.tooltip": "The low/high noise scale multiplier (Y) (scale * multiplier).",
 
   "config.farlands.estimatedPosition": "Estimated Far Lands X/Z",
   "config.farlands.estimatedFartherPosition": "Estimated Farther Lands X/Z",


### PR DESCRIPTION
They currently don't affect selector noise (#19), which is responsible for the Farther and Farthest Lands. Also, the low and high noise are both configured at the same time, resulting in traditional far lands (configuring them separately, like with CWG, results in even crazier effects). Making low and high noise separately configurable, alongside making selector noise configurable, comes under #39